### PR TITLE
Fix: Se actualiza ruta del registro

### DIFF
--- a/src/app/components/create/create.service.ts
+++ b/src/app/components/create/create.service.ts
@@ -6,7 +6,7 @@ import { Observable } from 'rxjs';
   providedIn: 'root'
 })
 export class CreateService {
-  private apiUrl = 'http://127.0.0.1:8000/api/registro/';
+  private apiUrl = 'http://127.0.0.1:8000/api/users/';
 
   constructor(private http: HttpClient) {}
 


### PR DESCRIPTION
This pull request includes a small change to the `CreateService` class in `src/app/components/create/create.service.ts`. The change updates the `apiUrl` property to point to a new endpoint for user-related operations.

* [`src/app/components/create/create.service.ts`](diffhunk://#diff-5784fc73816e9394ee4fd4f00f7fe076690a80e6cbc4d2adca111cf25af9e277L9-R9): Changed `apiUrl` from `'http://127.0.0.1:8000/api/registro/'` to `'http://127.0.0.1:8000/api/users/'`.